### PR TITLE
fix: information signal default

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ npm run compile:types
 The testing needs running Bee client node for integration testing.
 You must set `BEE_POSTAGE` environment variable with a valid Postage batch.
 
+In order to test on different node than `http://localhost:1633`, set `BEE_DEBUG_API_URL` environment variable as well.
+
 To run test execute
 
 ```sh

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ export class InformationSignal<UserPayload = AnyThreadComment> {
     this.consensusHash = keccak256Hash(options?.consensus?.id ?? DEFAULT_CONSENSUS_ID_2)
     this.fifo = options?.fifo ?? false
     this.bee = new Bee(beeApiUrl)
-    this.assertGraffitiRecord = options?.consensus?.assertRecord ?? assertGraffitiFeedRecord
+    this.assertGraffitiRecord = options?.consensus?.assertRecord ?? assertAnyThreadComment
   }
 
   async *read(options?: ReadOptions): AsyncGenerator<InformationSignalRead<UserPayload>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 import { Bee, Reference } from '@ethersphere/bee-js'
-import { keccak256Hash, numberToFeedIndex } from './utils'
+import { assertInformationSignalRecord, keccak256Hash, numberToFeedIndex } from './utils'
 import { getConsensualPrivateKey, getGraffitiWallet, serializeGraffitiRecord } from './graffiti-feed'
-import { AnyThreadComment, BeeJsSigner, Bytes, EthAddress, GraffitiFeedRecord, Signer } from './types'
+import {
+  AnyThreadComment,
+  BeeJsSigner,
+  Bytes,
+  EthAddress,
+  GraffitiFeedRecord,
+  InformationSignalRecord,
+  Signer,
+} from './types'
 import {
   assertAnyThreadComment,
   assertGraffitiFeedRecord,
@@ -287,7 +295,7 @@ export class PersonalStorageSignal<UserPayload = AnyThreadComment> {
   }
 }
 
-export class InformationSignal<UserPayload = AnyThreadComment> {
+export class InformationSignal<UserPayload = InformationSignalRecord> {
   public fifo: boolean
   public postageBatchId: string
   private bee: Bee
@@ -300,7 +308,7 @@ export class InformationSignal<UserPayload = AnyThreadComment> {
     this.consensusHash = keccak256Hash(options?.consensus?.id ?? DEFAULT_CONSENSUS_ID_2)
     this.fifo = options?.fifo ?? false
     this.bee = new Bee(beeApiUrl)
-    this.assertGraffitiRecord = options?.consensus?.assertRecord ?? assertAnyThreadComment
+    this.assertGraffitiRecord = options?.consensus?.assertRecord ?? assertInformationSignalRecord
   }
 
   async *read(options?: ReadOptions): AsyncGenerator<InformationSignalRead<UserPayload>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
 
 export const DEFAULT_RESOURCE_ID = 'any'
 const DEFAULT_POSTAGE_BATCH_ID = '0000000000000000000000000000000000000000000000000000000000000000'
-const DEFAULT_CONSENSUS_ID = 'AnyThread:v1'
+const DEFAULT_CONSENSUS_ID = 'AnyThread:v1' // used at personal storage signaling
+const DEFAULT_CONSENSUS_ID_2 = 'SimpleGraffitiFeed:v1' // used at information signaling
 
 interface BaseConstructorOptions<T = AnyThreadComment> {
   /**
@@ -296,7 +297,7 @@ export class InformationSignal<UserPayload = AnyThreadComment> {
 
   constructor(beeApiUrl: string, options?: ConstructorOptions<UserPayload>) {
     this.postageBatchId = options?.postageBatchId ?? DEFAULT_POSTAGE_BATCH_ID
-    this.consensusHash = keccak256Hash(options?.consensus?.id ?? DEFAULT_CONSENSUS_ID)
+    this.consensusHash = keccak256Hash(options?.consensus?.id ?? DEFAULT_CONSENSUS_ID_2)
     this.fifo = options?.fifo ?? false
     this.bee = new Bee(beeApiUrl)
     this.assertGraffitiRecord = options?.consensus?.assertRecord ?? assertGraffitiFeedRecord

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,3 +32,5 @@ export interface AnyThreadComment {
     blobType: string
   }
 }
+
+export type InformationSignalRecord = string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,13 @@
 import { Utils } from '@ethersphere/bee-js'
 import { Wallet } from 'ethers'
-import { AnyThreadComment, BeeJsSigner, EthAddress, GraffitiFeedRecord, Signer } from './types'
+import {
+  AnyThreadComment,
+  BeeJsSigner,
+  EthAddress,
+  GraffitiFeedRecord,
+  InformationSignalRecord,
+  Signer,
+} from './types'
 export const keccak256Hash = Utils.keccak256Hash
 export const hexToBytes = Utils.hexToBytes
 
@@ -75,5 +82,15 @@ function isAnyThreadComment(value: unknown): value is AnyThreadComment {
 export function assertAnyThreadComment(value: unknown): asserts value is AnyThreadComment {
   if (!isAnyThreadComment(value)) {
     throw new Error('The given value is not a valid personal storage record')
+  }
+}
+
+function isInformationSignalRecord(value: unknown): value is InformationSignalRecord {
+  return value !== null && typeof value === 'string'
+}
+
+export function assertInformationSignalRecord(value: unknown): asserts value is InformationSignalRecord {
+  if (!isInformationSignalRecord(value)) {
+    throw new Error('Value is not a valid Graffiti Feed Record')
   }
 }

--- a/test/integration/information-signal.spec.ts
+++ b/test/integration/information-signal.spec.ts
@@ -1,3 +1,6 @@
+import { Utils } from '@ethersphere/bee-js'
+import { HexString } from '@ethersphere/bee-js/dist/types/utils/hex'
+import { randomBytes } from 'crypto'
 import { InformationSignal } from '../../src'
 import { beeUrl, getPostageBatchId, getTestResourceId } from '../utils'
 
@@ -44,14 +47,19 @@ function getSignalInstances(): {
 
 describe('integration tests', () => {
   it('should write/read some data into the default GF', async () => {
-    const { zero_ } = getSignalInstances()
+    const zero_ = new InformationSignal(beeUrl(), { postageBatchId })
     const resourceId = getTestResourceId(1)
+    const message = {
+      text: 'Te menj előre a te hangod mélyebb',
+      timestamp: 1676990501732,
+      contentHash: Utils.bytesToHex(randomBytes(32)) as HexString<64>,
+    }
 
-    await zero_.write(text, { resourceId })
+    await zero_.write(message, { resourceId })
 
     const record = (await zero_.read({ resourceId }).next()).value.record
 
-    expect(record).toStrictEqual(text)
+    expect(record).toStrictEqual(message)
   })
 
   it('should read on empty graffiti feed', async () => {

--- a/test/integration/information-signal.spec.ts
+++ b/test/integration/information-signal.spec.ts
@@ -2,31 +2,23 @@ import { Utils } from '@ethersphere/bee-js'
 import { HexString } from '@ethersphere/bee-js/dist/types/utils/hex'
 import { randomBytes } from 'crypto'
 import { InformationSignal } from '../../src'
+import { AnyThreadComment } from '../../src/types'
+import { assertAnyThreadComment } from '../../src/utils'
 import { beeUrl, getPostageBatchId, getTestResourceId } from '../utils'
 
 const postageBatchId = getPostageBatchId()
 const dappId = 'information-signal-test:v1'
 const text = 'Kár érte, kiváló ügynök volt.' // for testing
-
-type TestRecord = string
-
-function isGraffitiFeedRecord(value: unknown): value is TestRecord {
-  return value !== null && typeof value === 'string'
-}
-
-export function assertGraffitiFeedRecord(value: unknown): asserts value is TestRecord {
-  if (!isGraffitiFeedRecord(value)) {
-    throw new Error('Value is not a valid Graffiti Feed Record')
-  }
-}
+const timestamp = 1676990501732
+const contentHash = Utils.bytesToHex(randomBytes(32)) as HexString<64>
 
 function getSignalInstances(): {
-  zero_: InformationSignal<TestRecord>
-  zero_any: InformationSignal<TestRecord>
+  zero_: InformationSignal<AnyThreadComment>
+  zero_any: InformationSignal<AnyThreadComment>
 } {
   const consensus = {
     id: dappId,
-    assertRecord: assertGraffitiFeedRecord,
+    assertRecord: assertAnyThreadComment,
   }
 
   const zero_ = new InformationSignal(beeUrl(), {
@@ -34,7 +26,7 @@ function getSignalInstances(): {
     postageBatchId,
   })
 
-  const zero_any = new InformationSignal<TestRecord>(beeUrl(), {
+  const zero_any = new InformationSignal<AnyThreadComment>(beeUrl(), {
     consensus: { id: consensus.id, assertRecord: () => true },
     postageBatchId,
   })
@@ -49,11 +41,7 @@ describe('integration tests', () => {
   it('should write/read some data into the default GF', async () => {
     const zero_ = new InformationSignal(beeUrl(), { postageBatchId })
     const resourceId = getTestResourceId(1)
-    const message = {
-      text: 'Te menj előre a te hangod mélyebb',
-      timestamp: 1676990501732,
-      contentHash: Utils.bytesToHex(randomBytes(32)) as HexString<64>,
-    }
+    const message = 'Te menj előre a te hangod mélyebb'
 
     await zero_.write(message, { resourceId })
 
@@ -73,9 +61,9 @@ describe('integration tests', () => {
   it('should write multiple records in graffiti feed', async () => {
     const { zero_ } = getSignalInstances()
     const resourceId = getTestResourceId(3)
-    const message1 = text + '1'
-    const message2 = text + '2'
-    const message3 = text + '3'
+    const message1 = { contentHash, text, timestamp: 1 }
+    const message2 = { contentHash, text, timestamp: 2 }
+    const message3 = { contentHash, text, timestamp: 3 }
 
     await zero_.write(message1, { resourceId })
     await zero_.write(message2, { resourceId })
@@ -97,12 +85,12 @@ describe('integration tests', () => {
   it('should skip a wrong record in Graffiti Feed', async () => {
     const { zero_, zero_any } = getSignalInstances()
     const resourceId = getTestResourceId(4)
-    const message1 = text + '1'
+    const message1 = { contentHash, text, timestamp: 1 }
     const message2 = 420
-    const message3 = text + '3'
+    const message3 = { contentHash, text, timestamp: 3 }
 
     await zero_.write(message1, { resourceId })
-    await zero_any.write(message2 as unknown as TestRecord, { resourceId })
+    await zero_any.write(message2 as unknown as AnyThreadComment, { resourceId })
     await zero_.write(message3, { resourceId })
 
     const graffitiIterator = zero_.read({ resourceId })


### PR DESCRIPTION
the PR contains slight changes regarding to default and types.
- InformationSignal has different default consensusId in order to not slow down the PersonalStorageSignal feed intentionally
- changed default record type for InformationSignal which accepts an arbitrary `string` now instead of `AnyThreadComment` 